### PR TITLE
Cleaner reading of old logs

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -85,26 +85,26 @@ function listdir_by_date($path){
 
 function getOldYSFReflectorLog() {
         $dir = YSFREFLECTORLOGPATH;
-        $scanlogs = SHOWOLDMHEARD;
+        $scannedLogs = 0;
         $oldlogLines = array();
 
         $dir_files = listdir_by_date($dir);
         
         foreach ($dir_files as $file) {
-            if ( $file != "." && $file != ".." ) {
-                if ( $scanlogs >= 0 ) {
-        
-                	if ($log = fopen(YSFREFLECTORLOGPATH."/".$file, 'r')) {
-                		while ($oldlogLine = fgets($log)) {
-    
-                                    if (strpos($oldlogLine, 'Received data from') !== false) {
-                			 	array_push($oldlogLines, $oldlogLine);
-                                    }
-    
-                		}
+            $filepath = $dir."/".$file;
+            if ( is_file( $filepath ) && substr( $filepath, -4 ) == '.log' ) {
+                if ($log = fopen($filepath, 'r')) {
+                        while ($oldlogLine = fgets($log)) {
+                                if (startsWith($oldlogLine, "M:")){
+                                        array_push($oldlogLines, $oldlogLine);
+                                }
+                        }
                         fclose($log);
-                	}
-                $scanlogs = $scanlogs - 1;
+
+                        $scannedLogs++;
+                        if ( $scannedLogs > SHOWOLDMHEARD ) {
+                                break;
+                        }
                 }
             }
         }


### PR DESCRIPTION
This fixes issue #25, which an acquaintance just ran into this weekend.

While the issue was technically caused by log files being stored in the the same folder as the app itself, it's really because getOldYSFReflectorLog was reading any and all entries (including directories) in the designated folder, rather than just log files (as well as by it using different logic to identify lines than getYSFReflectorLog` uses).

This update makes the following changes:
- Check if the current file is both an actual file, and ends in .log (this could be improved further, using YSFREFLECTORLOGPREFIX and/or having listdir_by_date use glob to match only the desired files in the first place?).
- Use the same startsWith test as getYSFReflectorLog uses to test if it's an applicable log line.
- Counts up to SHOWOLDMHEARD rather than down from (nitpicking), and stops looping once that limit is reached. It also only counts log files it succesfully opened.

This ensures that, regardless of where logs are stored, getOldYSFReflectorLog will return expected data (unless of course some other log files exist that have lines starting with M:).

This is arguably a bit of excessive idiot-proofing, but given how much of a pain it is to track down the cause from a DateTime parse error, it's probably worth it.