### PR TITLE
Fix `DISTRIBUTION` constant check for PHP 8.x

### DIFF
--- a/include/tools.php
+++ b/include/tools.php
@@ -66,7 +66,7 @@ function createConfigLines() {
 function checkSetup() {
    $el = error_reporting();
    error_reporting(E_ERROR | E_WARNING | E_PARSE);
-   if (defined(DISTRIBUTION)) {
+   if (defined("DISTRIBUTION")) {
 ?>
 <div class="alert alert-danger" role="alert"><?php echo _("You are using an old config.php. Please configure your Dashboard by calling <a href=\"setup.php\">setup.php</a>!"); ?></div>
 <?php


### PR DESCRIPTION
@dg9vh I know you are not maintaining this code anymore, but this is a super simple one-line patch which gets this functioning on PHP 8, so perhaps you'll consider it.

`defined()` wants a string, and modern PHP does not by default, coerce unknown constants to a string.